### PR TITLE
Update gui_launcher.py

### DIFF
--- a/src/gui_launcher.py
+++ b/src/gui_launcher.py
@@ -10,7 +10,7 @@ from os.path import exists, isfile, isdir
 from sys import executable
 
 if exists("./main.py") and isfile("./main.py"):
-    target_path = f"\"{executable}\" ./main.py"
+    target_path = f"\"\" \"{executable}\" ./main.py"
 elif exists("./main.exe") and isfile("./main.exe"):
     target_path = "./main.exe"
 else:


### PR DESCRIPTION
start 命令的第一个参数被解释为窗口标题，如果提供了一个双引号包围的字符串作为第一个参数，start 会认为它是窗口的标题而不是命令的一部分
添加一个空标题，这样就不会误将 Python 路径当作标题
建议以后还是用subprocess吧（目移）